### PR TITLE
fix: default postgres port number

### DIFF
--- a/flows/02_postgres_taxi.yaml
+++ b/flows/02_postgres_taxi.yaml
@@ -263,6 +263,6 @@ tasks:
 pluginDefaults:
   - type: io.kestra.plugin.jdbc.postgresql
     values:
-      url: jdbc:postgresql://host.docker.internal:5433/kestra
+      url: jdbc:postgresql://host.docker.internal:5432/kestra
       username: kestra
       password: k3str4

--- a/flows/02_postgres_taxi_scheduled.yaml
+++ b/flows/02_postgres_taxi_scheduled.yaml
@@ -251,7 +251,7 @@ tasks:
 pluginDefaults:
   - type: io.kestra.plugin.jdbc.postgresql
     values:
-      url: jdbc:postgresql://host.docker.internal:5433/kestra
+      url: jdbc:postgresql://host.docker.internal:5432/kestra
       username: kestra
       password: k3str4
 


### PR DESCRIPTION
Postgres Default port number is 5432, which is what the Kestra Docker Compose uses. Fixing examples to work with default kestra config.

Making PR to prevent inferring with changes on `main`.